### PR TITLE
Fix for error on python 3.8 Linux

### DIFF
--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -1,4 +1,5 @@
 import argparse, os, sys, glob
+sys.path.append('.')
 import cv2
 import torch
 import numpy as np
@@ -105,6 +106,7 @@ def main():
         default="a painting of a virus monster playing guitar",
         help="the prompt to render"
     )
+
     parser.add_argument(
         "--outdir",
         type=str,


### PR DESCRIPTION
Fixes

Traceback (most recent call last):
  File "scripts/txt2img.py", line 17, in <module>
    from ldm.util import instantiate_from_config
ModuleNotFoundError: No module named 'ldm'
