### PR TITLE
Update k-diffusion repo and update to SD v1.5 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Copy this github repository and extract the files.
 
 ### Download the CompVis Stable-diffusion model.
 
-Go here and download the correct mode from here. You'll have to agree to the license setup an account but this is the bread and butter AI art generating learning model.
+Go here and download the correct model from here. You'll have to agree to the license setup an account but this is the bread and butter AI art generating learning model.
 
-https://huggingface.co/CompVis/stable-diffusion-v-1-4-original
+https://huggingface.co/runwayml/stable-diffusion-v1-5
 
 copy the file to your stable-diffusion-cpuonly-main directory
 

--- a/install_sdco.bat
+++ b/install_sdco.bat
@@ -14,9 +14,9 @@ call pip install -e git+https://github.com/CompVis/taming-transformers.git@maste
 call pip install -e git+https://github.com/openai/CLIP.git@main#egg=clip
 call pip install -e git+https://github.com/TencentARC/GFPGAN#egg=GFPGAN
 call pip install -e git+https://github.com/xinntao/Real-ESRGAN#egg=realesrgan
-call pip install -e git+https://github.com/hlky/k-diffusion-sd#egg=k_diffusion
-copy sd-v1-4.ckpt "models/ldm/stable-diffusion-v1/model.ckpt"
-del sd-v1-4.ckpt
+call pip install -e git+https://github.com/crowsonkb/k-diffusion#egg=k_diffusion
+copy v1-5-pruned-emaonly.ckpt "models/ldm/stable-diffusion-v1/model.ckpt"
+del v1-5-pruned-emaonly.ckpt
 copy GFPGANv1.3.pth "src/gfpgan/experiments/pretrained_models/GFPGANv1.3.pth"
 del GFPGANv1.3.pth
 

--- a/install_sdco.sh
+++ b/install_sdco.sh
@@ -16,8 +16,8 @@ pip install -e git+https://github.com/CompVis/taming-transformers.git@master#egg
 pip install -e git+https://github.com/openai/CLIP.git@main#egg=clip
 pip install -e git+https://github.com/TencentARC/GFPGAN#egg=GFPGAN
 pip install -e git+https://github.com/xinntao/Real-ESRGAN#egg=realesrgan
-pip install -e git+https://github.com/hlky/k-diffusion-sd#egg=k_diffusion
-cp sd-v1-4.ckpt models/ldm/stable-diffusion-v1/model.ckpt
-rm sd-v1-4.ckpt
+pip install -e git+https://github.com/crowsonkb/k-diffusion#egg=k_diffusion
+cp v1-5-pruned-emaonly.ckpt models/ldm/stable-diffusion-v1/model.ckpt
+rm v1-5-pruned-emaonly.ckpt
 cp GFPGANv1.3.pth src/gfpgan/experiments/pretrained_models/GFPGANv1.3.pth
 rm GFPGANv1.3.pth


### PR DESCRIPTION
Fixed the error in install_sdco.bat and install_sdco.sh attempting to install from https://github.com/hlky/k-diffusion-sd, which is no longer available.  Replaced it with another k-diffusion repo at https://github.com/crowsonkb/k-diffusion.

Made changes to the install_sdco scripts to support the stable diffusion version 1.5 checkpoint file, "v1-5-pruned-emaonly.ckpt".  Changed the README.md file to show the URL to the stable diffusion v1-5 page on huggingface.co.